### PR TITLE
fix: Database objects missing when initially starting management api

### DIFF
--- a/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
+++ b/src/main/resources/liquibase/changelogs/v1_25_2/schema.yml
@@ -32,7 +32,14 @@ databaseChangeLog:
             columnName: subscription
             defaultNullValue: 'unknown'
             tableName: ratelimit
-        - modifyDataType:
+         - dropPrimaryKey:
+            constraintName: pk_ratelimit
+            tableName: ratelimit
+         - modifyDataType:
             tableName: ratelimit
             columnName: key
-            newDataType: nvarchar(128)
+            newDataType: nvarchar(128) not null
+         - addPrimaryKey:
+             constraintName: pk_ratelimit
+             columnNames: key
+             tableName: ratelimit


### PR DESCRIPTION
Closes gravitee-io/issues#3272